### PR TITLE
[#46] 마이페이지 API 연결 및 무한 스크롤 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,9 @@ import OrderStatistics from "@/pages/admin/OrderStatistics";
 import useAuthStore from "@/store/authStore";
 
 const App = () => {
+  //Production 확인용. 향후 삭제해야됨
+  console.log("현재 VITE MODE:", import.meta.env.MODE); 
+
   // Zustand persist가 자동으로 상태 복원
   const { isLoggedIn, user } = useAuthStore();
 

--- a/src/api/Mypage.ts
+++ b/src/api/Mypage.ts
@@ -7,7 +7,7 @@ export const fetchMyNormalOrders = async (): Promise<MyOrderResponse> => {
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('일반 주문 데이터 조회 실패:', error);
+        console.error('일반 주문 데이터 조회 실패');
         throw error;
     }
 };
@@ -19,7 +19,7 @@ export const fetchMyGroupOrders = async (): Promise<MyOrderResponse> => {
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('공동 주문 데이터 조회 실패:', error);
+        console.error('공동 주문 데이터 조회 실패');
         throw error;
     }
 };
@@ -31,7 +31,7 @@ export const fetchMyCustomDosiraks = async (): Promise<MyCustomDosirakResponse> 
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('나의 커스텀 도시락 데이터 조회 실패:', error);
+        console.error('나의 커스텀 도시락 데이터 조회 실패');
         throw error;
     }
 };
@@ -43,7 +43,7 @@ export const fetchMyNormalOrdersPreview = async (): Promise<MyOrderPreviewRespon
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('일반 주문 프리뷰 데이터 조회 실패:', error);
+        console.error('일반 주문 프리뷰 데이터 조회 실패');
         throw error;
     }
 };
@@ -55,7 +55,7 @@ export const fetchMyGroupOrdersPreview = async (): Promise<MyOrderPreviewRespons
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('공동 주문 프리뷰 데이터 조회 실패:', error);
+        console.error('공동 주문 프리뷰 데이터 조회 실패');
         throw error;
     }
 };
@@ -66,7 +66,7 @@ export const fetchMyCustomDosiraksPreview = async (): Promise<MyCustomDosirakRes
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('나의 커스텀 도시락 프리뷰 데이터 조회 실패:', error);
+        console.error('나의 커스텀 도시락 프리뷰 데이터 조회 실패');
         throw error;
     }
 };
@@ -77,7 +77,17 @@ export const fetchMyPageSummary = async (): Promise<MyPageSummary> => {
         console.log(response.data)
         return response.data;
     } catch (error) {
-        console.error('마이페이지 요약 데이터 조회 실패:', error);
+        console.error('마이페이지 요약 데이터 조회 실패');
+        throw error;
+    }
+};
+
+export const cancelOrder = async (orderId: number): Promise<void> => {
+    try {
+        await axiosInstance.delete(`/api/members/orders/${orderId}`);
+        console.log('주문 취소 완료');
+    } catch (error) {
+        console.error('주문 취소 실패');
         throw error;
     }
 };

--- a/src/api/Mypage.ts
+++ b/src/api/Mypage.ts
@@ -1,83 +1,99 @@
 import axiosInstance from "@/api/axiosInstance";
-import { MyOrderResponse, MyCustomDosirakResponse,  MyOrderPreviewResponse, MyPageSummary, } from "@/types/Mypage";
+import {
+    MyOrderResponse,
+    MyCustomDosirakResponse,
+    MyOrderPreviewResponse,
+    MyPageSummary,
+} from "@/types/Mypage";
 
-export const fetchMyNormalOrders = async (): Promise<MyOrderResponse> => {
+export const fetchMyNormalOrders = async (
+        orderId?: number,
+        count: number = 12
+    ): Promise<MyOrderResponse> => {
     try {
-        const response = await axiosInstance.get('/api/members/orders/normal');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/orders/normal", {
+            params: { orderId, count },
+        });
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('일반 주문 데이터 조회 실패');
+        console.error("일반 주문 데이터 조회 실패");
         throw error;
     }
 };
 
-
-export const fetchMyGroupOrders = async (): Promise<MyOrderResponse> => {
+export const fetchMyGroupOrders = async (
+        orderId?: number,
+        count: number = 12
+    ): Promise<MyOrderResponse> => {
     try {
-        const response = await axiosInstance.get('/api/members/orders/group');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/orders/group", {
+            params: { orderId, count },
+        });
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('공동 주문 데이터 조회 실패');
+        console.error("공동 주문 데이터 조회 실패");
         throw error;
     }
 };
 
-
-export const fetchMyCustomDosiraks = async (): Promise<MyCustomDosirakResponse> => {
+export const fetchMyCustomDosiraks = async (
+        orderId?: number,
+        count: number = 12
+    ): Promise<MyCustomDosirakResponse> => {
     try {
-        const response = await axiosInstance.get('/api/members/custom-dosirak');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/custom-dosirak", {
+            params: { orderId, count },
+        });
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('나의 커스텀 도시락 데이터 조회 실패');
+        console.error("나의 커스텀 도시락 데이터 조회 실패");
         throw error;
     }
 };
-
 
 export const fetchMyNormalOrdersPreview = async (): Promise<MyOrderPreviewResponse> => {
     try {
-        const response = await axiosInstance.get('/api/members/orders/normal/preview');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/orders/normal/preview");
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('일반 주문 프리뷰 데이터 조회 실패');
+        console.error("일반 주문 프리뷰 데이터 조회 실패");
         throw error;
     }
 };
 
-
 export const fetchMyGroupOrdersPreview = async (): Promise<MyOrderPreviewResponse> => {
     try {
-        const response = await axiosInstance.get('/api/members/orders/group/preview');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/orders/group/preview");
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('공동 주문 프리뷰 데이터 조회 실패');
+        console.error("공동 주문 프리뷰 데이터 조회 실패");
         throw error;
     }
 };
 
 export const fetchMyCustomDosiraksPreview = async (): Promise<MyCustomDosirakResponse> => {
     try {
-        const response = await axiosInstance.get('/api/members/custom-dosirak/preview');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/custom-dosirak/preview");
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('나의 커스텀 도시락 프리뷰 데이터 조회 실패');
+        console.error("나의 커스텀 도시락 프리뷰 데이터 조회 실패");
         throw error;
     }
 };
 
 export const fetchMyPageSummary = async (): Promise<MyPageSummary> => {
     try {
-        const response = await axiosInstance.get('/api/members/orders/summary');
-        console.log(response.data)
+        const response = await axiosInstance.get("/api/members/orders/summary");
+        console.log(response.data);
         return response.data;
     } catch (error) {
-        console.error('마이페이지 요약 데이터 조회 실패');
+        console.error("마이페이지 요약 데이터 조회 실패");
         throw error;
     }
 };
@@ -85,9 +101,9 @@ export const fetchMyPageSummary = async (): Promise<MyPageSummary> => {
 export const cancelOrder = async (orderId: number): Promise<void> => {
     try {
         await axiosInstance.delete(`/api/members/orders/${orderId}`);
-        console.log('주문 취소 완료');
+        console.log("주문 취소 완료");
     } catch (error) {
-        console.error('주문 취소 실패');
+        console.error("주문 취소 실패");
         throw error;
     }
 };

--- a/src/components/mypage/CustomDosirakList.tsx
+++ b/src/components/mypage/CustomDosirakList.tsx
@@ -1,4 +1,5 @@
 import styles from '@/css/mypage/CustomDosirakList.module.css';
+import { RefObject } from 'react';
 
 interface CustomDosirakItem {
     name: string;       // 도시락 이름
@@ -13,6 +14,7 @@ interface CustomDosirakListProps {
     onMoreClick?: () => void;           // 더보기 클릭시 실행할 함수
     hideHeader?: boolean;               // 헤더 숨김 여부
     limitItems?: number;                // 최대 몇개까지 도시락 보여줄지 제한
+    lastElementRef?: RefObject<HTMLDivElement>; // 마지막 요소 감지를 위한 ref
 }
 
 const CustomDosirakList = (props: CustomDosirakListProps) => {
@@ -60,10 +62,15 @@ const CustomDosirakList = (props: CustomDosirakListProps) => {
                         <p>등록된 커스텀 도시락이 없습니다.</p>
                     </div>
                 ) : (
-                    displayDosirakList.map((dosirak) => (
+                    displayDosirakList.map((dosirak, index) => (
                         <div 
                             key={dosirak.name + dosirak.createdAt}
                             className={styles.dosirakItem}
+                            ref={
+                                index === displayDosirakList.length - 1
+                                    ? props.lastElementRef
+                                    : undefined
+                            }
                         >
                             <div className={styles.dosirakImage}>
                                 <img src={dosirak.imageUrl} alt={dosirak.name} />

--- a/src/components/mypage/OrderHistoryList.tsx
+++ b/src/components/mypage/OrderHistoryList.tsx
@@ -69,7 +69,7 @@ const OrderHistoryList = (props: OrderHistoryListProps) => {
                         const totalAmount = calculateTotalAmount(order.items);
                         // 결제 대기, 결제 완료, 공구 모집인 경우에만 주문 취소 활성화
                         const cancelStatus = ['PAYMENT_PENDING', 'PAYMENT_COMPLETED', 'GONGGU_OPEN'];
-                        const canCancel = order.items.every(item => cancelStatus.includes(item.orderStatus));
+                        const canCancel = order.items.every(item => cancelStatus.includes(item.itemStatus));
 
                         return (
                             <div key={order.orderId} className={styles.orderGroup}>
@@ -121,9 +121,9 @@ const OrderHistoryList = (props: OrderHistoryListProps) => {
                                                 </div>
                                             </div>
                                             {!props.hideStatusBadge && (
-                                                <div className={styles.orderStatus}>
-                                                    <span className={`${styles.statusBadge} ${styles[`status${(item.orderStatus || '').replace(/\s/g, '')}`]}`}>
-                                                        {ORDER_STATUS_KR[item.orderStatus] ?? item.orderStatus}
+                                                <div className={styles.itemStatus}>
+                                                    <span className={`${styles.statusBadge} ${styles[`status${(item.itemStatus || '').replace(/\s/g, '')}`]}`}>
+                                                        {ORDER_STATUS_KR[item.itemStatus] ?? item.itemStatus}
                                                     </span>
                                                 </div>
                                             )}

--- a/src/components/mypage/OrderHistoryList.tsx
+++ b/src/components/mypage/OrderHistoryList.tsx
@@ -11,6 +11,7 @@ interface OrderHistoryListProps {
     hideOrderHeader?: boolean;                  // 주문별 헤더 (주문번호, 취소버튼) 활성화 여부
     hideStatusBadge?: boolean;                  // 주문별 상태 (결제대기, 결제완료) 활성화 여부
     limitItems?: number;                        // 주문 1건당 최대 몇개까지 보여줄지 제한
+    lastElementRef?: React.Ref<HTMLDivElement>; // 마지막 주문 DOM 참조 (무한스크롤용)
 }
 
 const OrderHistoryList = (props: OrderHistoryListProps) => {
@@ -65,14 +66,18 @@ const OrderHistoryList = (props: OrderHistoryListProps) => {
                         <p>주문 내역이 없습니다.</p>
                     </div>
                 ) : (
-                    displayOrderGroups.map((order) => {
+                    displayOrderGroups.map((order, index) => {
                         const totalAmount = calculateTotalAmount(order.items);
                         // 결제 대기, 결제 완료, 공구 모집인 경우에만 주문 취소 활성화
                         const cancelStatus = ['PAYMENT_PENDING', 'PAYMENT_COMPLETED', 'GONGGU_OPEN'];
                         const canCancel = order.items.every(item => cancelStatus.includes(item.itemStatus));
 
                         return (
-                            <div key={order.orderId} className={styles.orderGroup}>
+                            <div
+                                key={order.orderId}
+                                className={styles.orderGroup}
+                                ref={index === displayOrderGroups.length - 1 ? props.lastElementRef : null} // 마지막 요소에 ref 연결
+                            >
                                 {!props.hideOrderHeader && (
                                     <div className={styles.orderInfoHeader}>
                                         <div className={styles.orderHeaderLeft}>

--- a/src/constants/orderStatus.ts
+++ b/src/constants/orderStatus.ts
@@ -3,15 +3,15 @@ export const ORDER_STATUS_KR: Record<string, string> = {
   PAYMENT_COMPLETED: "결제 완료",
   PAYMENT_FAILED: "결제 실패",
   PAYMENT_CANCELLED: "결제 취소",
-  GONGGU_OPEN: "공구 모집",
-  GONGGU_CANCELLED: "공구 모집 취소",
+  GONGGOO_OPEN: "모집중",
+  GONGGOO_CONFIRMED: "모집 마감",
   DELIVERY_IN_PROGRESS: "배송 진행 중",
   DELIVERY_COMPLETED: "배송 완료",
 };
 
 export const ORDER_STATUS_LIST = [
   { code: "PAYMENT_COMPLETED", label: "결제 완료" },
-  { code: "GONGGU_CONFIRMED", label: "공구 모집 완료" },
+  { code: "GONGGOO_CONFIRMED", label: "공구 모집 마감" },
   { code: "DELIVERY_READY", label: "배송 준비 중" },
   { code: "DELIVERY_IN_PROGRESS", label: "배송 중" },
   { code: "DELIVERY_COMPLETED", label: "배송 완료" },

--- a/src/css/mypage/OrderHistoryList.module.css
+++ b/src/css/mypage/OrderHistoryList.module.css
@@ -139,6 +139,7 @@
     padding: 16px;
     background: #fff;
     border-top: 1px solid #eee;
+    gap: 24px;
 }
 
 /* 첫 번째 주문 아이템 */
@@ -230,8 +231,8 @@
 
 /* 결제 실패 */
 .statusPAYMENT_FAILED {
-    background: #f8d7da;
-    color: #721c24;
+    background: #f3e5e5;
+    color: #5a2e2e; 
 }
 
 /* 결제 취소 */
@@ -241,21 +242,21 @@
 }
 
 /* 공구 모집 */
-.statusGONGGU_OPEN {
-    background: #d1ecf1;
-    color: #0c5460;
+.statusGONGGOO_OPEN {
+    background: #d0ebff;
+    color: #0b5394;
 }
 
-/* 공구 모집 취소 */
-.statusGONGGU_CANCELLED {
-    background: #f5c6cb;
-    color: #721c24;
+/* 공구 모집 마감 */
+.statusGONGGOO_CONFIRMED {
+    background: #d4edda;
+    color: #155724;
 }
 
 /* 배송 진행 중 */
 .statusDELIVERY_IN_PROGRESS {
-    background: #cce5ff;
-    color: #004085;
+    background: #d0ebff;
+    color: #0b5394;
 }
 
 /* 배송 완료 */

--- a/src/pages/MyCustomDosiraks.tsx
+++ b/src/pages/MyCustomDosiraks.tsx
@@ -9,8 +9,6 @@ import CustomDosirakList from '@/components/mypage/CustomDosirakList';
 import OrderSummaryStatus from '@/components/mypage/OrderSummaryStatus';
 import Spinner from '@/components/common/Spinner';
 
-import { mockSummary, mockCustomDosiraks } from '@/mock/MypageMockData';
-
 function MyCustomDosiraks() {
     const navigate = useNavigate();
 
@@ -18,27 +16,24 @@ function MyCustomDosiraks() {
     const [customDosirakList, setCustomDosirakList] = useState<MyCustomDosirak[]>([]);    // 커스텀 도시락 배열
 
     useEffect(() => {
-        setUserSummary(mockSummary);
-        setCustomDosirakList(mockCustomDosiraks);
 
-        // API 연결시 아래 주석 해제
-        // const loadData = async () => {
-        //     try {
-        //         const [summaryData, dosirakData] = await Promise.all([
-        //             // fetchMyPageSummary(),
-        //             // fetchMyCustomDosiraks()
+        const loadData = async () => {
+            try {
+                const [summaryData, dosirakData] = await Promise.all([
+                    fetchMyPageSummary(),
+                    fetchMyCustomDosiraks()
                     
-        //         ]);
+                ]);
 
-        //         setUserSummary(summaryData);
-        //         setCustomDosirakList(dosirakData.customDosiraks);
+                setUserSummary(summaryData);
+                setCustomDosirakList(dosirakData.customDosiraks);
 
-        //     } catch (error) {
-        //         console.error('나의 커스텀 도시락 목록 불러오기 실패:', error);
-        //     }
-        // };
+            } catch (error) {
+                console.error('커스텀 도시락 정보를 불러오는데 문제가 발생했습니다.');
+            }
+        };
 
-        // loadData();
+        loadData();
     }, []);
 
     // 도시락 생성하기 버튼 클릭시 실행

--- a/src/pages/MyCustomDosiraks.tsx
+++ b/src/pages/MyCustomDosiraks.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MyPageSummary, MyCustomDosirak } from '@/types/Mypage';
 import { fetchMyCustomDosiraks, fetchMyPageSummary } from '@/api/Mypage';
@@ -14,20 +14,45 @@ function MyCustomDosiraks() {
 
     const [userSummary, setUserSummary] = useState<MyPageSummary | null>(null); // 사용자 정보
     const [customDosirakList, setCustomDosirakList] = useState<MyCustomDosirak[]>([]);    // 커스텀 도시락 배열
+    const [lastDosirakId, setLastDosirakId] = useState<number | undefined>(undefined); // 마지막 도시락 ID
+    const [hasMore, setHasMore] = useState(true); // 더 불러올 데이터 여부
+    const [isLoading, setIsLoading] = useState(false); // 로딩 중 여부
+
+    const observer = useRef<IntersectionObserver | null>(null);
+    const lastElementRef = useRef<HTMLDivElement | null>(null);
+
+    // 커스텀 도시락 불러오기 함수
+    const loadDosiraks = useCallback(async () => {
+        if (isLoading || !hasMore) return;
+        setIsLoading(true);
+
+        try {
+            const res = await fetchMyCustomDosiraks(lastDosirakId, 12);
+            const newList = res.customDosiraks;
+
+            setCustomDosirakList(prev => [...prev, ...newList]);
+
+            if (newList.length < 12) {
+                setHasMore(false);
+            } else {
+                setLastDosirakId(newList[newList.length - 1].dosirakId);
+            }
+        } catch (error) {
+            console.error('커스텀 도시락 정보를 불러오는데 문제가 발생했습니다.');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [lastDosirakId, isLoading, hasMore]);
 
     useEffect(() => {
-
         const loadData = async () => {
             try {
-                const [summaryData, dosirakData] = await Promise.all([
-                    fetchMyPageSummary(),
-                    fetchMyCustomDosiraks()
-                    
+                const [summaryData] = await Promise.all([
+                    fetchMyPageSummary()
                 ]);
 
                 setUserSummary(summaryData);
-                setCustomDosirakList(dosirakData.customDosiraks);
-
+                await loadDosiraks();
             } catch (error) {
                 console.error('커스텀 도시락 정보를 불러오는데 문제가 발생했습니다.');
             }
@@ -35,6 +60,25 @@ function MyCustomDosiraks() {
 
         loadData();
     }, []);
+
+    // IntersectionObserver로 마지막 요소 감지
+    useEffect(() => {
+        if (!hasMore || isLoading) return;
+
+        if (observer.current) observer.current.disconnect();
+
+        observer.current = new IntersectionObserver(entries => {
+            if (entries[0].isIntersecting) {
+                loadDosiraks();
+            }
+        });
+
+        if (lastElementRef.current) {
+            observer.current.observe(lastElementRef.current);
+        }
+
+        return () => observer.current?.disconnect();
+    }, [customDosirakList, hasMore, isLoading, loadDosiraks]);
 
     // 도시락 생성하기 버튼 클릭시 실행
     const handleAddDosirak = () => {
@@ -74,7 +118,15 @@ function MyCustomDosiraks() {
                 dosirakList={customDosirakList}
                 showMoreButton={false}
                 hideHeader={false}
+                lastElementRef={lastElementRef}
             />
+
+            {/* 로딩 중일 때 하단 스피너 */}
+            {isLoading && (
+                <div className={styles.spinnerBottomWrapper}>
+                    <Spinner />
+                </div>
+            )}
         </div>
     );
 }

--- a/src/pages/MyGroupOrders.tsx
+++ b/src/pages/MyGroupOrders.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { fetchMyGroupOrders, fetchMyPageSummary, cancelOrder } from '@/api/Mypage';
-import { MyPageSummary } from '@/types/Mypage';
+import { MyOrder, MyPageSummary } from '@/types/Mypage';
 
 import styles from '@/css/main/MyGroupOrders.module.css';
 
@@ -10,18 +10,43 @@ import Spinner from '@/components/common/Spinner';
 
 function MyGroupOrders () {
     const [userSummary, setUserSummary] = useState<MyPageSummary | null>(null); // 사용자 정보
-    const [groupOrder, setGroupOrder] = useState([]);   // 공동 주문 내역
+    const [groupOrder, setGroupOrder] = useState<MyOrder[]>([]);   // 공동 주문 내역
+    const [lastOrderId, setLastOrderId] = useState<number | undefined>(undefined); // 마지막 주문 ID
+    const [hasMore, setHasMore] = useState(true); // 더 불러올 주문이 있는지 여부
+    const [isLoading, setIsLoading] = useState(false); // API 로딩 상태
+
+    const observer = useRef<IntersectionObserver | null>(null);
+    const lastOrderRef = useRef<HTMLDivElement | null>(null);
+
+    // 주문 불러오기 함수
+    const loadOrders = useCallback(async () => {
+        if (isLoading || !hasMore) return;
+        setIsLoading(true);
+
+        try {
+            const res = await fetchMyGroupOrders(lastOrderId, 6);
+            const newOrders = res.orders;
+
+            setGroupOrder(prev => [...prev, ...newOrders]);
+
+            if (newOrders.length < 6) {
+                setHasMore(false);
+            } else {
+                setLastOrderId(newOrders[newOrders.length - 1].orderId);
+            }
+        } catch (error) {
+            console.error("공동 주문 데이터를 불러오는 데 문제가 발생했습니다.");
+        } finally {
+            setIsLoading(false);
+        }
+    }, [lastOrderId, hasMore, isLoading]);
 
     useEffect(() => {
         const loadData = async () => {
             try {
-                const [summaryData, orderData] = await Promise.all([
-                    fetchMyPageSummary(),
-                    fetchMyGroupOrders()
-                ]);
-
-                setGroupOrder(orderData.orders);
+                const summaryData = await fetchMyPageSummary();
                 setUserSummary(summaryData);
+                await loadOrders();
             } catch (error) {
                 console.error("공동 주문 데이터를 불러오는 데 문제가 발생했습니다.");
             }
@@ -29,6 +54,25 @@ function MyGroupOrders () {
 
         loadData();
     }, []);
+
+    // IntersectionObserver로 마지막 주문 감지
+    useEffect(() => {
+        if (!hasMore || isLoading) return;
+
+        if (observer.current) observer.current.disconnect();
+
+        observer.current = new IntersectionObserver((entries) => {
+            if (entries[0].isIntersecting) {
+                loadOrders();
+            }
+        });
+
+        if (lastOrderRef.current) {
+            observer.current.observe(lastOrderRef.current);
+        }
+
+        return () => observer.current?.disconnect();
+    }, [groupOrder, hasMore, isLoading, loadOrders]);
 
     // 주문 취소 버튼 클릭시 실행
     const handleOrderCancel = async (orderId: number) => {
@@ -74,7 +118,15 @@ function MyGroupOrders () {
                 showMoreButton={false}
                 hideOrderHeader={false}
                 hideStatusBadge={false}
+                lastElementRef={lastOrderRef}
             />
+
+            {/* 로딩 중일 때 하단 스피너 */}
+            {isLoading && (
+                <div className={styles.spinnerBottomWrapper}>
+                    <Spinner />
+                </div>
+            )}
         </div>
     );
 };

--- a/src/pages/MyNormalOrders.tsx
+++ b/src/pages/MyNormalOrders.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { fetchMyNormalOrders, fetchMyPageSummary } from '@/api/Mypage';
+import { fetchMyNormalOrders, fetchMyPageSummary, cancelOrder } from '@/api/Mypage';
 import { MyPageSummary } from '@/types/Mypage';
 
 import styles from '@/css/main/MyNormalOrders.module.css';
@@ -8,50 +8,40 @@ import OrderHistoryList from '@/components/mypage/OrderHistoryList';
 import OrderSummaryStatus from '@/components/mypage/OrderSummaryStatus';
 import Spinner from '@/components/common/Spinner';
 
-import { mockSummary, mockOrders } from '@/mock/MypageMockData';
-
 function MyNormalOrders() {
     const [userSummary, setUserSummary] = useState<MyPageSummary | null>(null); // 사용자 정보
     const [normalOrder, setNormalOrder] = useState([]); // 공동 주문 내역
 
     useEffect(() => {
-        setUserSummary(mockSummary);
-        setNormalOrder(mockOrders);
-        // API 연결시 아래 주석 해제
-        // const loadData = async () => {
-        //     try {
-        //         const [summaryData, orderData] = await Promise.all([
-        //             fetchMyPageSummary(),
-        //             fetchMyNormalOrders()
-        //         ]);
+        const loadData = async () => {
+            try {
+                const [summaryData, orderData] = await Promise.all([
+                    fetchMyPageSummary(),
+                    fetchMyNormalOrders()
+                ]);
 
-        //         setNormalOrder(orderData.orders);
-        //         setUserSummary(summaryData);
-        //     } catch (error) {
-        //         console.error("일반 주문 데이터 불러오기 실패:", error);
-        //     }
-        // };
+                setNormalOrder(orderData.orders);
+                setUserSummary(summaryData);
+            } catch (error) {
+                console.error("일반 주문 데이터를 불러오는 데 문제가 발생했습니다.");
+            }
+        };
 
-        // loadData();
+        loadData();
     }, []);
 
     // 주문 취소 버튼 클릭시 실행
-    const handleOrderCancel = (orderId: number) => {
-        // TODO: 여기서 주문 취소로 이어져야합니다.
-        setNormalOrder(prev => 
-            prev.map(group => 
-                group.orderId === orderId 
-                    ? { 
-                        ...group, 
-                        canCancel: false, 
-                        items: group.items.map(item => ({ 
-                            ...item, 
-                            orderStatus: '주문 취소'
-                        })) 
-                    }
-                    : group
-            )
-        );
+    const handleOrderCancel = async (orderId: number) => {
+        const isConfirmed = window.confirm("정말 이 주문을 취소하시겠습니까?");
+        if (!isConfirmed) return;
+
+        try {
+            await cancelOrder(orderId);
+            alert('주문이 취소되었습니다.');
+            window.location.reload();
+        } catch (error) {
+            alert('주문 취소에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        }
     };
 
     // 페이지 로딩시 스피너 리턴

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -23,13 +23,6 @@ import {
     MyPageSummary
 } from '@/types/Mypage';
 
-import {
-    mockSummary,
-    mockNormalPreview,
-    mockGroupPreview,
-    mockCustomDosiraksPreview
-} from '@/mock/MypageMockData';
-
 function Mypage() {
     const navigate = useNavigate();
     const contentLayoutRef = useRef<HTMLDivElement>(null);
@@ -87,7 +80,7 @@ function Mypage() {
                 imageUrl: data.imageUrl,
                 price: data.price,
                 amount: data.amount,
-                orderStatus: data.orderStatus
+                itemStatus: data.itemStatus
             })),
         };
 
@@ -96,36 +89,29 @@ function Mypage() {
 
     // 데이터 로딩
     useEffect(() => {
-        const mockNormalOrders = mapPreviewsToSingleOrder(mockNormalPreview);
-        const mockGroupOrders = mapPreviewsToSingleOrder(mockGroupPreview);
-        setNormalOrder(mockNormalOrders);
-        setGroupOrder(mockGroupOrders);
-        setCustomDosirakList(mockCustomDosiraksPreview);
-        setUserSummary(mockSummary);
-        // API 연결시 아래 주석 해제
-        // const fetchData = async () => {
-        //     try {
-        //         const [normalPreview, groupPreview, customPreview, summary] = await Promise.all([
-        //             fetchMyNormalOrdersPreview(),
-        //             fetchMyGroupOrdersPreview(),
-        //             fetchMyCustomDosiraksPreview(),
-        //             fetchMyPageSummary()
-        //         ]);
+        const fetchData = async () => {
+            try {
+                const [normalPreview, groupPreview, customPreview, summary] = await Promise.all([
+                    fetchMyNormalOrdersPreview(),
+                    fetchMyGroupOrdersPreview(),
+                    fetchMyCustomDosiraksPreview(),
+                    fetchMyPageSummary()
+                ]);
 
-        //         // 각 프리뷰 데이터를 하나의 주문으로 묶음
-        //         const normalOrders: MyOrder[] = mapPreviewsToSingleOrder(normalPreview.orders);
-        //         const groupOrders: MyOrder[] = mapPreviewsToSingleOrder(groupPreview.orders);
+                // 각 프리뷰 데이터를 하나의 주문으로 묶음
+                const normalOrders: MyOrder[] = mapPreviewsToSingleOrder(normalPreview.orders);
+                const groupOrders: MyOrder[] = mapPreviewsToSingleOrder(groupPreview.orders);
 
-        //         setNormalOrder(normalOrders);
-        //         setGroupOrder(groupOrders);
-        //         setCustomDosirakList(customPreview.customDosiraks);
-        //         setUserSummary(summary);
-        //     } catch (error) {
-        //         console.error('데이터 불러오기 실패:', error);
-        //     }
-        // };
+                setNormalOrder(normalOrders);
+                setGroupOrder(groupOrders);
+                setCustomDosirakList(customPreview.customDosiraks);
+                setUserSummary(summary);
+            } catch (error) {
+                console.error('데이터를 불러오지 못했습니다');
+            }
+        };
 
-        // fetchData();
+        fetchData();
     }, []);
 
     // 내용 높이 정렬 - 데이터 변경될 때

--- a/src/types/Mypage.ts
+++ b/src/types/Mypage.ts
@@ -34,6 +34,7 @@ export interface MyOrderPreviewResponse{
 
 // 나의 커스텀 도시락 내역 관련
 export interface MyCustomDosirak {
+    dosirakId: number,
     name: string;
     imageUrl: string;
     createdAt: string;

--- a/src/types/Mypage.ts
+++ b/src/types/Mypage.ts
@@ -5,7 +5,7 @@ export interface MyOrderItem {
     imageUrl: string;
     price: number;
     amount: number;
-    orderStatus: string;
+    itemStatus: string;
 }
 
 export interface MyOrder {
@@ -25,7 +25,7 @@ export interface MyOrderPreview{
     price: number;
     amount: number;
     orderDate: string;
-    orderStatus: string;
+    itemStatus: string;
 }
 
 export interface MyOrderPreviewResponse{


### PR DESCRIPTION
## #️⃣ Issue Number
#46 

## 📝 요약(Summary)
마이페이지(홈, 일반주문내역, 공동주문내역, 나만의커스텀)에 API 연결하였습니다.
- 내역 조회 API 연결
- 주문 취소 API 연결

무한스크롤 적용사항
- 주문 내역의 경우 한번에 6개의 주문씩 출력되게 했습니다.
- 나의 커스텀 도시락의 경우 한번에 도시락 12개씩이 출력됩니다.
- 이후부턴 사용자가 스크롤을 내리게 되면 6(12)개씩 더 불러오는 방식

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).